### PR TITLE
Update DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -354,3 +354,4 @@ If you need to debug the tests:
 
 The `debugger;` statement is needed because WebStorm will stop in a transpiled file. Breakpoints in
 the original source files are not supported at the moment.
+approve_regex: '^(Approved|:shipit:)'


### PR DESCRIPTION
We recommend starting with ^, to only match strings at the beginning of a line. In our experience this makes approval more intentional, and also avoids issues with comments via email where previous content may be embedded in a blockquote (>) that could otherwise trigger mistaken approval.
